### PR TITLE
Fix can't parse `PP_CHI` & `PP_BETA`

### DIFF
--- a/src/UPF.jl
+++ b/src/UPF.jl
@@ -1,6 +1,6 @@
 using AcuteML
 
-export UPF
+export UPF, getdata
 
 istrue(str) = occursin(r"t(rue)?"i, str)
 
@@ -157,20 +157,9 @@ function Base.parse(::Type{UPF}, str)
     return UPF(doc)
 end
 
-function Base.getproperty(x::Union{RhoAtom,Local,R,Rab,Chi,Beta}, name::Symbol)
-    if name == :data
-        return parsevec(x.text)
-    else
-        return getfield(x, name)
-    end
-end
-function Base.getproperty(x::Dij, name::Symbol)
-    if name == :data
-        return parse(Float64, x.text)
-    else
-        return getfield(x, name)
-    end
-end
+getdata(x::Union{RhoAtom,Local,R,Rab,Chi,Beta}) = parsevec(x.text)
+getdata(x::Dij) = parse(Float64, x.text)
+
 function Base.getproperty(x::Header, name::Symbol)
     if name in (
         :is_ultrasoft,


### PR DESCRIPTION
Parsing `//PP_PSWFC/PP_CHI.n` and `//PP_NONLOCAL/PP_BETA.n` was not possible because 

> [the enumeration of elements in UPF that does not comply with the extensive nature of XML: <PP_BETA.1> <PP_BETA.2> etc.](https://esl.cecam.org/data/upf/)

Therefore, I could only manually modify the XML source before parsing, i.e., make the `PP_CHI.1-PP_CHI.n` to be a standard XML list. The method is implemented in `fixenumeration!`.

Besides, I mades some other changes:
- Renamed `checkmesh` to `validate`, use multiple dispatch on different types to distinguish different checks.
- Deprecate `Base.getproperty` on some types (`RhoAtom,Local,R,Rab,Chi,Beta,Dij`), use `getdata` instead. This helps to avoid errors and cache mechanism of `getdata` can be added in the future.