### PR TITLE
Deprecate type `PseudopotentialFormat`

### DIFF
--- a/docs/src/api/Pseudopotentials.md
+++ b/docs/src/api/Pseudopotentials.md
@@ -13,7 +13,6 @@ Depth = 3
 
 ```@docs
 Pseudopotential
-PseudopotentialFormat
 ExchangeCorrelationFunctional
 Pseudization
 ```

--- a/src/Pseudopotentials.jl
+++ b/src/Pseudopotentials.jl
@@ -32,7 +32,7 @@ export PerdewZunger,
 """
     Pseudopotential
 
-Represent a pseudopotential file.
+Represent any pseudopotential file.
 """
 abstract type Pseudopotential end
 

--- a/src/Pseudopotentials.jl
+++ b/src/Pseudopotentials.jl
@@ -37,22 +37,6 @@ Represent a pseudopotential file.
 abstract type Pseudopotential end
 
 """
-    PseudopotentialFormat
-
-Represent all possible pseudopotential data formats.
-
-There are different standards for pseudopotential data formats, such as
-- [PAW-XML](https://esl.cecam.org/data/paw-xml/),
-- [PSML](https://esl.cecam.org/data/psml/),
-- [FDF](https://esl.cecam.org/data/fdf/),
-- [ESCDF](https://esl.cecam.org/data/escdf/),
-- [UPF](https://esl.cecam.org/data/upf/),
-- [ETSF_IO](https://esl.cecam.org/data/etsf_io/),
-- [Libxc IDs](https://esl.cecam.org/data/libxc/).
-"""
-abstract type PseudopotentialFormat end
-
-"""
     ExchangeCorrelationFunctional
 
 Represent exchange-correlation functional types.


### PR DESCRIPTION
Only keep `Pseudopotential`